### PR TITLE
perf: build ipv6 regex directly

### DIFF
--- a/src/ipv6.js
+++ b/src/ipv6.js
@@ -27,13 +27,13 @@ const IP_RANGES = [
   /^::1?$/
 ]
 
-const regex = () => new RegExp(`^(${IP_RANGES.map(re => re.source).join('|')})$`)
+const regex = new RegExp(`^(${IP_RANGES.map(re => re.source).join('|')})$`)
 
 module.exports = hostname => {
   if (hostname.startsWith('[') && hostname.endsWith(']')) {
     hostname = hostname.slice(1, -1)
   }
-  return regex().test(hostname)
+  return regex.test(hostname)
 }
 
-module.exports.regex = regex()
+module.exports.regex = regex


### PR DESCRIPTION
```
const isLocalAddress = require('is-local-address/ipv6')
isLocalAddress(new URL('http://[::]:3000').hostname) // true
isLocalAddress(new URL('http://[::]:3000').hostname) // true
isLocalAddress(new URL('http://[::]:3000').hostname) // true
```

With the current implementation, the regex will be built every time `is-local-address/ipv6` is called. This hurts performance.

The PR changes that the regex will only be built once.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/5766d6df-f69b-4da1-a6c8-ca4263f9c122" />

All tests passed on my machine.

Also, this won't hurt cold start performance (since currently, `module.exports.regex = regex()` will build regex on start anyway).